### PR TITLE
updraftSettings singleton and signal

### DIFF
--- a/src/features/common/state/index.ts
+++ b/src/features/common/state/index.ts
@@ -1,10 +1,7 @@
+export * from './updraft-settings';
+
 import { createContext } from '@lit/context';
-
-import { Connection, UpdraftSettings } from '@/types';
-
-export const defaultFunderReward = 250000; // 25% assuming the percent scale set on the Updraft contract is 1,000,000
+import { Connection } from '@/types';
 
 // DEPRECATED: Legacy connection context - use userContext from features/user/state/user instead
 export const connectionContext = createContext<Connection>('connection');
-export const updraftSettings =
-  createContext<UpdraftSettings>('updraftSettings');

--- a/src/features/common/state/updraft-settings.ts
+++ b/src/features/common/state/updraft-settings.ts
@@ -1,0 +1,30 @@
+import { signal, computed } from '@lit-labs/signals';
+
+import { UpdraftSettings } from '@/types';
+import { updraft } from '@contracts/updraft';
+import { formatUnits } from 'viem';
+
+export const updraftSettings = signal<UpdraftSettings>({
+  percentScale: 1000000,
+  updAddress: '0x',
+  percentFee: 0,
+  minFee: 0,
+});
+
+export const refreshUpdraftSettings = async () => {
+  const percentScaleBigInt = (await updraft.read('percentScale')) as bigint;
+  const minFee = (await updraft.read('minFee')) as bigint;
+  const percentFee = (await updraft.read('percentFee')) as bigint;
+  const percentScale = Number(percentScaleBigInt);
+  const updAddress = (await updraft.read('feeToken')) as `0x${string}`;
+  updraftSettings.set({
+    percentScale,
+    updAddress,
+    percentFee: Number(percentFee) / percentScale,
+    minFee: Number(formatUnits(minFee, 18)),
+  });
+};
+
+export const defaultFunderReward = computed(
+  () => updraftSettings.get().percentScale * 0.25
+);

--- a/src/features/idea/components/idea-card-large.ts
+++ b/src/features/idea/components/idea-card-large.ts
@@ -1,6 +1,6 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, css } from 'lit';
+import { html, SignalWatcher } from '@lit-labs/signals';
 import { customElement, property } from 'lit/decorators.js';
-import { consume } from '@lit/context';
 import { formatUnits, fromHex } from 'viem';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -15,12 +15,11 @@ import '@shoelace-style/shoelace/dist/components/card/card.js';
 
 import { defaultFunderReward, updraftSettings } from '@state/common';
 import { Idea } from '@/features/idea/types';
-import { UpdraftSettings } from '@/features/common/types';
 
 import { shortNum } from '@utils/short-num';
 
 @customElement('idea-card-large')
-export class IdeaCardLarge extends LitElement {
+export class IdeaCardLarge extends SignalWatcher(LitElement) {
   static styles = css`
     :host {
       display: block;
@@ -115,8 +114,6 @@ export class IdeaCardLarge extends LitElement {
   `;
 
   @property() idea!: Idea;
-  @consume({ context: updraftSettings, subscribe: true })
-  updraftSettings?: UpdraftSettings;
 
   render() {
     const {
@@ -130,9 +127,9 @@ export class IdeaCardLarge extends LitElement {
       name,
     } = this.idea;
     let pctFunderReward;
-    if (funderReward != defaultFunderReward && this.updraftSettings) {
+    if (funderReward != defaultFunderReward.get()) {
       pctFunderReward =
-        (funderReward * 100) / this.updraftSettings.percentScale;
+        (funderReward * 100) / updraftSettings.get().percentScale;
     }
     const interest = shortNum(formatUnits(shares, 18));
     const profile = JSON.parse(

--- a/src/features/idea/components/idea-card-small.ts
+++ b/src/features/idea/components/idea-card-small.ts
@@ -1,6 +1,6 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, css } from 'lit';
+import { html, SignalWatcher } from '@lit-labs/signals';
 import { customElement, property } from 'lit/decorators.js';
-import { consume } from '@lit/context';
 import { formatUnits } from 'viem';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -15,12 +15,11 @@ import '@shoelace-style/shoelace/dist/components/icon/icon.js';
 
 import { defaultFunderReward, updraftSettings } from '@state/common';
 import { Idea } from '@/features/idea/types';
-import { UpdraftSettings } from '@/features/common/types';
 
 import { shortNum } from '@utils/short-num';
 
 @customElement('idea-card-small')
-export class IdeaCardSmall extends LitElement {
+export class IdeaCardSmall extends SignalWatcher(LitElement) {
   static styles = css`
     :host {
       display: inline-block;
@@ -75,16 +74,14 @@ export class IdeaCardSmall extends LitElement {
   `;
 
   @property() idea!: Idea;
-  @consume({ context: updraftSettings, subscribe: true })
-  updraftSettings?: UpdraftSettings;
 
   render() {
     const { startTime, funderReward, shares, description, id, name } =
       this.idea;
     let pctFunderReward;
-    if (funderReward != defaultFunderReward && this.updraftSettings) {
+    if (funderReward != defaultFunderReward.get()) {
       pctFunderReward =
-        (funderReward * 100) / this.updraftSettings.percentScale;
+        (funderReward * 100) / updraftSettings.get().percentScale;
     }
     const interest = shortNum(formatUnits(shares, 18));
     const date = dayjs(startTime * 1000);

--- a/src/features/pages/create-idea.ts
+++ b/src/features/pages/create-idea.ts
@@ -1,7 +1,6 @@
 import { customElement, query, state } from 'lit/decorators.js';
 import { css } from 'lit';
 import { html, SignalWatcher } from '@lit-labs/signals';
-import { consume } from '@lit/context';
 
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
@@ -18,14 +17,10 @@ import { SaveableForm } from '@components/common/saveable-form';
 
 import { getBalance, refreshBalances } from '@state/user/balances';
 import { updraftSettings } from '@state/common';
-import { UpdraftSettings } from '@/features/common/types';
 
 @customElement('create-idea')
 export class CreateIdea extends SignalWatcher(SaveableForm) {
   @query('upd-dialog', true) updDialog!: UpdDialog;
-
-  @consume({ context: updraftSettings, subscribe: true })
-  updraftSettings!: UpdraftSettings;
 
   @state() private depositError: string | null = null;
   @state() private antiSpamFee?: string;
@@ -116,7 +111,7 @@ export class CreateIdea extends SignalWatcher(SaveableForm) {
     const input = e.target as SlInput;
     const value = Number(input.value);
     const userBalance = getBalance('updraft');
-    const minFee = this.updraftSettings.minFee;
+    const minFee = updraftSettings.get().minFee;
 
     if (isNaN(value)) {
       this.depositError = 'Enter a number';
@@ -138,7 +133,7 @@ export class CreateIdea extends SignalWatcher(SaveableForm) {
     if (isNaN(value)) {
       fee = minFee;
     } else {
-      fee = Math.max(minFee, value * this.updraftSettings.percentFee);
+      fee = Math.max(minFee, value * updraftSettings.get().percentFee);
     }
     this.antiSpamFee = fee.toFixed(2);
   }

--- a/src/features/pages/create-solution-page-two.ts
+++ b/src/features/pages/create-solution-page-two.ts
@@ -12,7 +12,7 @@ import { SaveableForm } from '@components/common/saveable-form';
 
 import { dialogStyles } from '@styles/dialog-styles';
 
-import { updraftSettings as updraftSettingsContext } from '@state/common';
+import { updraftSettings } from '@state/common';
 import { userContext, UserState } from '@state/user';
 import layout from '@state/layout';
 
@@ -25,7 +25,6 @@ import '@components/common/upd-dialog';
 import '@components/common/share-dialog';
 import '@components/common/label-with-hint';
 
-import { UpdraftSettings } from '@/types';
 import { IdeaDocument } from '@gql';
 import urqlClient from '@utils/urql-client';
 import { getBalance, refreshBalances } from '@state/user/balances';
@@ -43,8 +42,6 @@ export class CreateSolution extends SignalWatcher(SaveableForm) {
   @query('share-dialog', true) shareDialog!: ShareDialog;
   @query('sl-dialog', true) approveDialog!: SlDialog;
 
-  @consume({ context: updraftSettingsContext, subscribe: true })
-  updraftSettings!: UpdraftSettings;
   @consume({ context: userContext, subscribe: true })
   userState!: UserState;
 
@@ -192,7 +189,7 @@ export class CreateSolution extends SignalWatcher(SaveableForm) {
     const input = e.target as SlInput;
     const value = Number(input.value);
     const userBalance = getBalance('updraft');
-    const minFee = this.updraftSettings.minFee;
+    const minFee = updraftSettings.get().minFee;
 
     if (isNaN(value)) {
       this.depositError = 'Enter a number';
@@ -214,7 +211,7 @@ export class CreateSolution extends SignalWatcher(SaveableForm) {
     if (isNaN(value)) {
       fee = minFee;
     } else {
-      fee = Math.max(minFee, value * this.updraftSettings.percentFee);
+      fee = Math.max(minFee, value * updraftSettings.get().percentFee);
     }
     this.antiSpamFee = fee.toFixed(2);
   }


### PR DESCRIPTION
Replaced the outdated `@lit/context` consume-based settings with a centralized `updraftSettings` signal managed in a new `state/updraft-settings.ts` module. Simplified logic for accessing and calculating settings across components, improving maintainability. Removed unnecessary complexity and repetitive code, consolidating functionality to align with the new state management pattern.